### PR TITLE
integrator-extension server uses winston.Logger() instance

### DIFF
--- a/server.js
+++ b/server.js
@@ -83,7 +83,7 @@ var consoleTransportOpts = {
   prettyPrint: true
 };
 
-var logger = new (winston.Logger)()
+var logger = null
 var fileTransport = new winstonDailyRotateFile(fileTransportOpts)
 var consoleTransport = new winston.transports.Console(consoleTransportOpts)
 var winstonTransports = [fileTransport, consoleTransport]


### PR DESCRIPTION
1. Change integrator-extension to use a winston.Logger() instance and pass that in to express-winston
2. However, we'll only use a winston.Logger() instance if extension is running as a server. If we're running as a module we'll use the default loggers as normal
