### PR TITLE
integrator-extension server uses winston.Logger() instance

### DIFF
--- a/server.js
+++ b/server.js
@@ -70,7 +70,6 @@ expressWinston.requestWhitelist.push('query');
 
 var message = "{{res.statusCode}} HTTP {{req.method}} {{req.url}} {{res.responseTime}}ms"
 var expressWinstonOps = {
-  winstonInstance: logger,
   msg: message,
   meta: false
 }


### PR DESCRIPTION
1. Change integrator-extension to use a winston.Logger() instance and pass that in to express-winston
2. However, we'll only use a winston.Logger() instance if extension is running as a server. If we're running as a module we'll use the default loggers as normal
