### PR TITLE
integrator-extension server uses winston.Logger() instance

### DIFF
--- a/server.js
+++ b/server.js
@@ -17,7 +17,7 @@ https.globalAgent.maxSockets = Infinity
 var _ = require('lodash');
 var express = require('express');
 var app = express();
-var logger = require('winston')
+var winston = require('winston')
 var winstonDailyRotateFile = require('winston-daily-rotate-file')
 var expressWinston = require('express-winston');
 var bodyParser = require('body-parser');
@@ -43,23 +43,24 @@ var fileTransportOpts = {
   maxFiles: 2,
   json: false,
   handleExceptions: (process.env.NODE_ENV === 'production')
-};
+}
 
 var consoleTransportOpts = {
   colorize: true,
   timestamp :true,
   prettyPrint: true
-};
+}
 
-var fileTransport = new winstonDailyRotateFile(fileTransportOpts);
-var consoleTransport = new logger.transports.Console(consoleTransportOpts);
+var logger = null
+var fileTransport = new winstonDailyRotateFile(fileTransportOpts)
+var consoleTransport = new winston.transports.Console(consoleTransportOpts)
+var winstonTransports = [fileTransport, consoleTransport]
 
 // Gives an error when module is installed in integrator for testing
 // Add loggers only when not running as a module
 if (__dirname.indexOf('node_modules') === -1) {
-  logger.remove(logger.transports.Console)
-  logger.add(logger.transports.Console, consoleTransportOpts)
-  logger.add(winstonDailyRotateFile, fileTransportOpts)
+  logger = new (winston.Logger)()
+  logger.configure({ transports: winstonTransports })
 }
 
 expressWinston.requestWhitelist.splice(0, expressWinston.requestWhitelist.length);
@@ -68,17 +69,20 @@ expressWinston.requestWhitelist.push('url');
 expressWinston.requestWhitelist.push('query');
 
 var message = "{{res.statusCode}} HTTP {{req.method}} {{req.url}} {{res.responseTime}}ms"
-var expressWinstonLogger = expressWinston.logger({
-  transports: [fileTransport, consoleTransport],
+var expressWinstonOps = {
   msg: message,
   meta: false
-});
+}
 
-var expressWinstonErrorLogger = expressWinston.errorLogger({
-  transports: [fileTransport, consoleTransport],
-  msg: message,
-  meta: false
-});
+if (logger) {
+  expressWinstonOps.winstonInstance = logger
+} else {
+  expressWinstonOps.transports = winstonTransports
+  logger = winston
+}
+
+var expressWinstonLogger = expressWinston.logger(expressWinstonOps)
+var expressWinstonErrorLogger = expressWinston.errorLogger(expressWinstonOps)
 
 // we need the logs from all our 3rd party modules.
 var consoleOpts = ['log', 'profile', 'startTimer'];


### PR DESCRIPTION
1. Change integrator-extension to use a winston.Logger() instance and pass that in to express-winston
2. However, we'll only use a winston.Logger() instance if extension is running as a server. If we're running as a module we'll use the default loggers as normal
